### PR TITLE
Fix indentation in MigrateToRules via AutoFormatVisitor

### DIFF
--- a/src/main/java/org/openrewrite/gitlab/MigrateToRules.java
+++ b/src/main/java/org/openrewrite/gitlab/MigrateToRules.java
@@ -22,6 +22,7 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.YamlParser;
+import org.openrewrite.yaml.format.AutoFormatVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.ArrayList;
@@ -65,10 +66,13 @@ public class MigrateToRules extends Recipe {
                             return m;
                         }
 
-                        if (onlyEntry != null) {
-                            return migrateWithOnly(m, onlyEntry, exceptEntry);
+                        Yaml.Mapping result = onlyEntry != null ?
+                                migrateWithOnly(m, onlyEntry, exceptEntry) :
+                                migrateExceptOnly(m, exceptEntry);
+                        if (result != m) {
+                            doAfterVisit(new AutoFormatVisitor<>(null));
                         }
-                        return migrateExceptOnly(m, exceptEntry);
+                        return result;
                     }
                 }
         );
@@ -96,26 +100,17 @@ public class MigrateToRules extends Recipe {
             }
         }
 
-        String entryPrefix = onlyEntry.getPrefix();
-        String baseIndent = entryPrefix.contains("\n") ?
-                entryPrefix.substring(entryPrefix.lastIndexOf('\n') + 1) : "  ";
-        String indentUnit = detectIndentUnit(baseIndent, (Yaml.Sequence) onlyEntry.getValue());
-        String seqIndent = baseIndent + indentUnit;
-        String contentIndent = seqIndent + "  ";
-
+        // Build with deeply-indented sequence entries so Autodetect picks indented-sequence
+        // style; AutoFormatVisitor re-indents to the document's actual indent width.
         StringBuilder sb = new StringBuilder("rules:");
-
-        // Except refs come first as 'when: never'
         if (exceptRefs != null && !exceptRefs.isEmpty()) {
             for (String ref : exceptRefs) {
-                sb.append("\n").append(seqIndent).append("- if: ").append(refToCondition(ref));
-                sb.append("\n").append(contentIndent).append("when: never");
+                sb.append("\n        - if: ").append(refToCondition(ref));
+                sb.append("\n          when: never");
             }
         }
-
-        // Only refs as positive rules
         for (String ref : onlyRefs) {
-            sb.append("\n").append(seqIndent).append("- if: ").append(refToCondition(ref));
+            sb.append("\n        - if: ").append(refToCondition(ref));
         }
 
         Yaml.Mapping.Entry rulesEntry = parseRulesEntry(sb.toString(), onlyEntry.getPrefix());
@@ -145,19 +140,12 @@ public class MigrateToRules extends Recipe {
             return m;
         }
 
-        String entryPrefix = exceptEntry.getPrefix();
-        String baseIndent = entryPrefix.contains("\n") ?
-                entryPrefix.substring(entryPrefix.lastIndexOf('\n') + 1) : "  ";
-        String indentUnit = detectIndentUnit(baseIndent, (Yaml.Sequence) exceptEntry.getValue());
-        String seqIndent = baseIndent + indentUnit;
-        String contentIndent = seqIndent + "  ";
-
         StringBuilder sb = new StringBuilder("rules:");
         for (String ref : refs) {
-            sb.append("\n").append(seqIndent).append("- if: ").append(refToCondition(ref));
-            sb.append("\n").append(contentIndent).append("when: never");
+            sb.append("\n        - if: ").append(refToCondition(ref));
+            sb.append("\n          when: never");
         }
-        sb.append("\n").append(seqIndent).append("- when: always");
+        sb.append("\n        - when: always");
 
         Yaml.Mapping.Entry rulesEntry = parseRulesEntry(sb.toString(), exceptEntry.getPrefix());
         if (rulesEntry == null) {
@@ -190,21 +178,6 @@ public class MigrateToRules extends Recipe {
                 .map(mapping -> mapping.getEntries().get(0).withPrefix(prefix))
                 .findFirst()
                 .orElse(null);
-    }
-
-    private static String detectIndentUnit(String baseIndent, Yaml.Sequence seq) {
-        List<Yaml.Sequence.Entry> entries = seq.getEntries();
-        if (entries.isEmpty()) {
-            return "  ";
-        }
-        String childPrefix = entries.get(0).getPrefix();
-        String childIndent = childPrefix.contains("\n") ?
-                childPrefix.substring(childPrefix.lastIndexOf('\n') + 1) : "";
-        int increment = childIndent.length() - baseIndent.length();
-        if (increment <= 0) {
-            return "  ";
-        }
-        return childIndent.substring(baseIndent.length());
     }
 
     static String refToCondition(String ref) {

--- a/src/main/java/org/openrewrite/gitlab/MigrateToRules.java
+++ b/src/main/java/org/openrewrite/gitlab/MigrateToRules.java
@@ -99,7 +99,8 @@ public class MigrateToRules extends Recipe {
         String entryPrefix = onlyEntry.getPrefix();
         String baseIndent = entryPrefix.contains("\n") ?
                 entryPrefix.substring(entryPrefix.lastIndexOf('\n') + 1) : "  ";
-        String seqIndent = baseIndent + "  ";
+        String indentUnit = detectIndentUnit(baseIndent, (Yaml.Sequence) onlyEntry.getValue());
+        String seqIndent = baseIndent + indentUnit;
         String contentIndent = seqIndent + "  ";
 
         StringBuilder sb = new StringBuilder("rules:");
@@ -147,7 +148,8 @@ public class MigrateToRules extends Recipe {
         String entryPrefix = exceptEntry.getPrefix();
         String baseIndent = entryPrefix.contains("\n") ?
                 entryPrefix.substring(entryPrefix.lastIndexOf('\n') + 1) : "  ";
-        String seqIndent = baseIndent + "  ";
+        String indentUnit = detectIndentUnit(baseIndent, (Yaml.Sequence) exceptEntry.getValue());
+        String seqIndent = baseIndent + indentUnit;
         String contentIndent = seqIndent + "  ";
 
         StringBuilder sb = new StringBuilder("rules:");
@@ -188,6 +190,21 @@ public class MigrateToRules extends Recipe {
                 .map(mapping -> mapping.getEntries().get(0).withPrefix(prefix))
                 .findFirst()
                 .orElse(null);
+    }
+
+    private static String detectIndentUnit(String baseIndent, Yaml.Sequence seq) {
+        List<Yaml.Sequence.Entry> entries = seq.getEntries();
+        if (entries.isEmpty()) {
+            return "  ";
+        }
+        String childPrefix = entries.get(0).getPrefix();
+        String childIndent = childPrefix.contains("\n") ?
+                childPrefix.substring(childPrefix.lastIndexOf('\n') + 1) : "";
+        int increment = childIndent.length() - baseIndent.length();
+        if (increment <= 0) {
+            return "  ";
+        }
+        return childIndent.substring(baseIndent.length());
     }
 
     static String refToCondition(String ref) {

--- a/src/test/java/org/openrewrite/gitlab/MigrateToRulesTest.java
+++ b/src/test/java/org/openrewrite/gitlab/MigrateToRulesTest.java
@@ -349,6 +349,80 @@ class MigrateToRulesTest implements RewriteTest {
     }
 
     @Test
+    void migrateFourSpaceIndentOnly() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              build_job:
+                  script: make build
+                  only:
+                      - main
+                      - tags
+              """,
+            """
+              build_job:
+                  script: make build
+                  rules:
+                      - if: $CI_COMMIT_BRANCH == 'main'
+                      - if: $CI_COMMIT_TAG
+              """,
+            source -> source.path(".gitlab-ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void migrateFourSpaceIndentExcept() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              build_job:
+                  script: make build
+                  except:
+                      - tags
+              """,
+            """
+              build_job:
+                  script: make build
+                  rules:
+                      - if: $CI_COMMIT_TAG
+                        when: never
+                      - when: always
+              """,
+            source -> source.path(".gitlab-ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void migrateFourSpaceIndentCombined() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              build_job:
+                  script: make build
+                  only:
+                      - branches
+                  except:
+                      - main
+              """,
+            """
+              build_job:
+                  script: make build
+                  rules:
+                      - if: $CI_COMMIT_BRANCH == 'main'
+                        when: never
+                      - if: $CI_COMMIT_BRANCH
+              """,
+            source -> source.path(".gitlab-ci.yml")
+          )
+        );
+    }
+
+    @Test
     void noopForNonGitlabCiFiles() {
         rewriteRun(
           //language=yaml


### PR DESCRIPTION
## Summary
- `MigrateToRules` hardcoded 2-space indent increments when building the replacement `rules:` block, producing mixed indentation on files using 4-space (or other) indent widths.
- Build the new `rules:` block with a deeply-indented sequence snippet and schedule `AutoFormatVisitor` via `doAfterVisit` so the YAML library re-indents the inserted entry to the document's detected indent style.
- The deep indent is deliberate: Autodetect samples only the newly-inserted sequence (the original `only`/`except` sequence is gone by then), so the snippet must use indented-sequence style to avoid being detected as same-column — a short comment calls this out.

## Test plan
- [x] Three new tests for 4-space indentation: `only`, `except`, and combined `only`+`except`
- [x] All existing `MigrateToRulesTest` tests continue to pass
- [x] `./gradlew test` passes